### PR TITLE
Fix parsing response for Create Monitor

### DIFF
--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -77,6 +77,11 @@ type Monitor struct {
 	DockerHost          int           `json:"docker_host,omitempty"`
 }
 
+type MonitorCreateResponse struct {
+	Msg                 string        `json:"msg,omitempty"`
+	MonitorID           int           `json:"monitorID,omitempty"`
+}
+
 // GetMonitors retrieves all monitors
 func (c *Client) GetMonitors(ctx context.Context) ([]Monitor, error) {
 	var result []Monitor
@@ -97,13 +102,13 @@ func (c *Client) GetMonitor(ctx context.Context, id int) (*Monitor, error) {
 }
 
 // CreateMonitor creates a new monitor
-func (c *Client) CreateMonitor(ctx context.Context, monitor *Monitor) (*Monitor, error) {
+func (c *Client) CreateMonitor(ctx context.Context, monitor *Monitor) (*MonitorCreateResponse, error) {
 	data, err := json.Marshal(monitor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal monitor: %w", err)
 	}
 
-	var result Monitor
+	var result MonitorCreateResponse
 	if err := c.Post(ctx, "/monitors", bytes.NewReader(data), &result); err != nil {
 		return nil, fmt.Errorf("failed to create monitor: %w", err)
 	}

--- a/internal/provider/monitor_resource.go
+++ b/internal/provider/monitor_resource.go
@@ -262,7 +262,7 @@ func (r *MonitorResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Update Terraform state
-	data.ID = types.Int64Value(int64(createdMonitor.ID))
+	data.ID = types.Int64Value(int64(createdMonitor.MonitorID))
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
The `POST` to `/monitor` for creating a new Monitor object responds with a `{ msg : String, monitorID : Int}` object (Source: https://github.com/lucasheld/uptime-kuma-api/blob/master/uptime_kuma_api/api.py#L1463-L1466), which is not correctly parsed nor typed currently.

With these small changes, the Monitor ID is successfully parsed and added to the Terraform state and can then the object state can be consequently refreshed.